### PR TITLE
Fix package

### DIFF
--- a/cljr-helm.el
+++ b/cljr-helm.el
@@ -6,7 +6,7 @@
 ;; URL      : https://github.com/philjackson/cljr-helm
 ;; Version  : 0.9
 ;; Keywords : helm, clojure, refactor
-;; Package-Requires: ((clj-refactor "0.13.0") (helm-core "1.7.7"))
+;; Package-Requires: ((clj-refactor "0.13.0") (helm-core "1.7.7") (cl-lib "0.5"))
 
 ;; This file is part of GNU Emacs.
 
@@ -39,10 +39,11 @@
 ;;; Code:
 
 (require 'helm)
+(require 'clj-refactor)
 
 (defun cljr-helm-candidates ()
   (mapcar (lambda (c)
-            (concat (car c) ": " (second (cdr c))))
+            (concat (car c) ": " (cl-second (cdr c))))
           cljr--all-helpers))
 
 (defvar helm-source-cljr


### PR DESCRIPTION
- Load cl-lib for using its function(second is an alias of `cl-second`)
- Load clj-refactor explicitly

This fixes following byte-compile warnings.

```
In cljr-helm-candidates:
cljr-helm.el:46:11:Warning: reference to free variable ‘cljr--all-helpers’

In end of data:
cljr-helm.el:66:1:Warning: the function ‘second’ is not known to be defined.
```
